### PR TITLE
FIX: texto sobre img_persona

### DIFF
--- a/_layouts/persona.html
+++ b/_layouts/persona.html
@@ -6,7 +6,7 @@ layout: base
 
 <div class="container" role="main">
   <div class="row">
-   <div class="col-sm-2">
+   <div class="col-sm-2" style="margin: 2px;">
 		<img 
 			src="{{ site.baseurl }}/personas_img{{ page.url | remove_first: "/con"}}.jpg"
 			class="image-responsive center-block"


### PR DESCRIPTION
Las 2 columnas no son suficientes para algunas img_persona . Agregarle un margin es una solucion simple para que la imagen se pueda ver completa.